### PR TITLE
Readme fix

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,7 +78,8 @@ No worries, I understand :)
 First, include Phoenix as a plugin in your 'project.clj':
 
 #+BEGIN_SRC clojure
-  {:plugins [jarohen/phoenix "0.1.2"]}
+  :plugins [[jarohen/phoenix "0.1.2"]
+             ...]
 #+END_SRC
 
 Next, make a small config file on your classpath - let's say, in the

--- a/README.org
+++ b/README.org
@@ -93,7 +93,7 @@ Then, tell Phoenix where to find your main config file by putting a
 =:phoenix/config= key in your 'project.clj':
 
 #+BEGIN_SRC clojure
-  {:phoenix/config "config/myapp-config.edn"}
+  :phoenix/config "myapp-config.edn"
 #+END_SRC
 
 Now, if you run =lein phoenix=, you should see the nREPL server


### PR DESCRIPTION
Couple of very simple changes for the readme while I was going through it..

Another thing to mention would be that while in the readme.org it's mentioned
'resources' directory, at 'config/myapp-config.edn':

but  using the lein template the created configuration is not inside config but inside resources, not a big deal anyway but might be slightly confusing..
